### PR TITLE
tcmu-runner implicit failover support

### DIFF
--- a/ceph_iscsi_config/client.py
+++ b/ceph_iscsi_config/client.py
@@ -159,8 +159,12 @@ class GWClient(object):
             # and cleanup before the initiator has begun recovery and
             # failed over.
             self.acl.set_attribute('dataout_timeout', '20')        # default  3
-            self.acl.set_attribute('nopin_response_timeout', '10') # default 30
-            self.acl.set_attribute('nopin_timeout', '10')          # default 15
+            # LIO default 30
+            self.acl.set_attribute('nopin_response_timeout','{}'.format(
+                                   settings.config.nopin_response_timeout))
+            # LIO default 15
+            self.acl.set_attribute('nopin_timeout', '{}'.format(
+                                   settings.config.nopin_timeout))
         except RTSLibError as err:
             self.logger.error("(Client.define_client) FAILED to define "
                               "{}".format(self.iqn))

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -308,14 +308,13 @@ class GWTarget(object):
                                  "group id {}".format(stg_object.name, tpg.tag))
                 group_name = "ao"
                 alua_tpg = ALUATargetPortGroup(stg_object, group_name, tpg.tag)
-                # alua_tpg.alua_access_state = 0
-                alua_tpg.preferred = 1
+                alua_tpg.alua_access_state = 0
             else:
                 self.logger.info("setting {} to ALUA/ActiveNONOptimised "
                                  "group id {}".format(stg_object.name, tpg.tag))
                 group_name = "ano{}".format(tpg.tag)
                 alua_tpg = ALUATargetPortGroup(stg_object, group_name, tpg.tag)
-                # alua_tpg.alua_access_state = 1
+                alua_tpg.alua_access_state = 1
         except RTSLibError as err:
                 self.logger.info("ALUA group id {} for stg obj {} lun {} "
                                  "already made".format(tpg.tag, stg_object, lun))
@@ -329,17 +328,13 @@ class GWTarget(object):
                 # drop down in case we are restarting due to error and we
                 # were not able to bind to a lun last time.
 
-        # alua_tpg.alua_access_type = 1
-
-        # start ports in Standby, and let the initiator drive the initial
-        # transition to AO.
         self.logger.debug("ALUA defined, updating state")
-        alua_tpg.alua_access_state = 2
-        alua_tpg.alua_access_type = 3
+        # Use implicit failover
+        alua_tpg.alua_access_type = 1
 
         alua_tpg.alua_support_offline = 0
-        alua_tpg.alua_support_unavailable = 0
-        alua_tpg.alua_support_standby = 1
+        alua_tpg.alua_support_unavailable = 1
+        alua_tpg.alua_support_standby = 0
         alua_tpg.alua_support_transitioning = 1
         alua_tpg.implicit_trans_secs = 60
         alua_tpg.nonop_delay_msecs = 0

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -610,18 +610,30 @@ class LUN(object):
                                               config=cfgstring,
                                               size=self.size_bytes,
                                               wwn=in_wwn)
-
-            new_lun.set_attribute("cmd_time_out", 0);
         except RTSLibError as err:
             self.error = True
             self.error_msg = ("failed to add {} to LIO - "
                              "error({})".format(self.config_key,
                                                 str(err)))
             self.logger.error(self.error_msg)
+            return None
 
-        else:
-            self.logger.info("(LUN.add_dev_to_lio) Successfully added {}"
-                             " to LIO".format(self.config_key))
+        try:
+            new_lun.set_attribute("cmd_time_out", 0)
+            new_lun.set_attribute("qfull_time_out",
+                                  settings.config.qfull_timeout)
+        except RTSLibError as err:
+            self.error = True
+            self.error_msg = ("Could not set LIO device attribute "
+                             "cmd_time_out/qfull_time_out for device: {}. "
+                             "Kernel not supported. - "
+                             "error({})".format(self.config_key, str(err)))
+            self.logger.error(self.error_msg)
+            new_lun.delete()
+            return None
+
+        self.logger.info("(LUN.add_dev_to_lio) Successfully added {}"
+                         " to LIO".format(self.config_key))
 
         return new_lun
 

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -600,9 +600,11 @@ class LUN(object):
 
         new_lun = None
         try:
-            # config string = rbd identifier / config_key (pool/image)
-            cfgstring = "rbd/{}/{}".format(self.pool,
-                                         self.image)
+            # config string = rbd identifier / config_key (pool/image) /
+            # optional osd timeout
+            cfgstring = "rbd/{}/{}/osd_op_timeout={}".format(self.pool,
+                                         self.image,
+                                         settings.config.osd_op_timeout)
 
             new_lun = UserBackedStorageObject(name=self.config_key,
                                               config=cfgstring,

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -33,6 +33,9 @@ class Settings(object):
                 "pub_key": 'iscsi-gateway-pub.key'
                 }
 
+    target_defaults = {"osd_op_timeout": 30
+                       }
+
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):
 
         self.size_suffixes = ['M', 'G', 'T']
@@ -45,12 +48,21 @@ class Settings(object):
         if len(dataset) == 0:
             # no config file present, set up defaults
             self._define_settings(Settings.defaults)
+            self._define_settings(Settings.target_defaults)
         else:
             # If we have a file use it to override the defaults
             if config.has_section("config"):
                 runtime_settings = dict(Settings.defaults)
                 runtime_settings.update(dict(config.items("config")))
                 self._define_settings(runtime_settings)
+
+            if config.has_section("target"):
+                target_settings = dict(Settings.target_defaults)
+                target_settings.update(dict(config.items("target")))
+                self._define_settings(target_settings)
+            else:
+                # We always want these values set to at least the defaults.
+                self._define_settings(Settings.target_defaults)
 
         self.cephconf = '/etc/ceph/{}.conf'.format(self.cluster_name)
         if self.api_secure:

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -35,7 +35,8 @@ class Settings(object):
 
     target_defaults = {"osd_op_timeout": 30,
                        "nopin_response_timeout" : 5,
-                       "nopin_timeout" : 5
+                       "nopin_timeout" : 5,
+                       "qfull_timeout" : 5
                        }
 
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -33,7 +33,9 @@ class Settings(object):
                 "pub_key": 'iscsi-gateway-pub.key'
                 }
 
-    target_defaults = {"osd_op_timeout": 30
+    target_defaults = {"osd_op_timeout": 30,
+                       "nopin_response_timeout" : 5,
+                       "nopin_timeout" : 5
                        }
 
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):


### PR DESCRIPTION
These patches replace the explicit failover support for implicit. 

- The first patch just resets the path state  initialization back to the implicit values we used before. Here we are using AO and ANO, where the AO path is the preferred one. We do not set the preferred bit, because some initiators ignore it. They will automatically use the AO path first.

- Implicit failover requires timers on the target side to be set low enough to detect and fail IO (or have taken the rbd lock) before the initiator's failover timer has fired. The rest of the patches set the necessary timers.