### PR TITLE
lun: fix import requests that use 0G for rbd image size

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -373,7 +373,7 @@ class LUN(object):
             # requested image is already defined to ceph
 
             if rbd_image.valid:
-
+                self.size_bytes = rbd_image._get_size_bytes()
                 # rbd image is OK to use, so ensure it's in the config
                 # object
                 if self.config_key not in self.config.config['disks']:


### PR DESCRIPTION
When a disk create request is received, but the image already exists
we now just get the size directly from the current rbd. This way the
user can just specify a size of 0g (don't care), and the import will
proceed.