### PR TITLE
[RFC] ceph iscsi config: add max_data_area setting

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -617,7 +617,8 @@ class LUN(object):
             new_lun = UserBackedStorageObject(name=self.config_key,
                                               config=cfgstring,
                                               size=self.size_bytes,
-                                              wwn=in_wwn)
+                                              wwn=in_wwn,
+                                              max_data_area_mb=settings.config.max_data_area_mb)
         except RTSLibError as err:
             self.error = True
             self.error_msg = ("failed to add {} to LIO - "
@@ -625,6 +626,11 @@ class LUN(object):
                                                 str(err)))
             self.logger.error(self.error_msg)
             return None
+
+        if new_lun.max_data_area_mb is None:
+            self.logger.warning("Could not set max_data_area_mb for {}."
+                                "Kernel does not support this feature.".
+                                format(self.config_key))
 
         try:
             new_lun.set_attribute("cmd_time_out", 0)

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -36,7 +36,8 @@ class Settings(object):
     target_defaults = {"osd_op_timeout": 30,
                        "nopin_response_timeout" : 5,
                        "nopin_timeout" : 5,
-                       "qfull_timeout" : 5
+                       "qfull_timeout" : 5,
+                       "max_data_area_mb" : 8
                        }
 
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):


### PR DESCRIPTION
Allow users to config the tcmu data area ring size.

This reqiures a updated kernel with the patch:

https://www.spinics.net/lists/target-devel/msg16097.html

and a updated rtslib with this PR merged:

https://github.com/open-iscsi/rtslib-fb/pull/112

This is marked a RFC because we are still waiting on upstream testing/review, so the patch should not be merged yet.