### PR TITLE
service: set TimeoutStopSec to infinity

### DIFF
--- a/usr/lib/systemd/system/rbd-target-gw.service
+++ b/usr/lib/systemd/system/rbd-target-gw.service
@@ -21,6 +21,7 @@ PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+TimeoutStopSec=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When there are outstanding IOs, if there has any slow IO, such the
FORMAT command with very large size of a block deivce. When the gw
service try to clear the config by rmove the target device, it will
be stuck in kernel by waiting the app's reply.

If the FORMAT take too long, such about 20-minutes, then the systemd
will kill the gw service. This could cause some bugs, such as:

rbd-target-gw[649712]: Removing LUNs from LIO
rbd-target-gw[649712]: Removing iSCSI target from LIO
rbd-target-gw[649712]: Removing Ceph iSCSI configuration from LIO
rbd-target-gw[649712]: Error unable to register rbd.block5 with LIO
		- failed to add rbd.block5 to LIO - error(This
		_Backstore already exists in configFS)
rbd-target-gw[649712]: failed to add rbd.block5 to LIO - error(This
		_Backstore already exists in configFS)

Without this patch then We must reboot the machine to fix this.

This patch just avoid the gw service killed by systemd and wait the
outstanding IOs just complete.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>