### PR TITLE
fix gateway_keyring setting

### DIFF
--- a/ceph_iscsi_config/common.py
+++ b/ceph_iscsi_config/common.py
@@ -32,7 +32,9 @@ class CephCluster(object):
         self.error = False
         self.error_msg = ''
         self.cluster = rados.Rados(conffile=settings.config.cephconf,
-                                   conf=dict(keyring="/etc/ceph/{}".format(settings.config.gateway_keyring)))
+                                   conf=dict(keyring="{}/{}".format(
+                                             settings.config.ceph_config_dir,
+                                             settings.config.gateway_keyring)))
         try:
             self.cluster.connect()
         except rados.Error as err:

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -16,7 +16,7 @@ def init():
 class Settings(object):
 
     defaults = {"cluster_name": "ceph",
-                "gateway_keyring": "/etc/ceph/ceph.client.admin.keyring",
+                "gateway_keyring": "ceph.client.admin.keyring",
                 "time_out": 30,
                 "api_port": 5000,
                 "api_secure": "true",


### PR DESCRIPTION
The default gateway_keyring is set as the filename and path,
but when the user sets it it can only be the filename because
we merge it with "/etc/ceph".

This fixes the initialization so it is only the filename
and it also has us use the ceph_config_dir instead of
hard coding /etc/ceph.