### PR TITLE
lun: fix lun resize on local gateway

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -407,6 +407,7 @@ class LUN(object):
                 self.logger.info("rbd image {} resized "
                                  "to {}".format(self.config_key,
                                                 self.size))
+                self.size_bytes = rbd_image._get_size_bytes()
                 self.num_changes += 1
             else:
                 self.logger.debug("rbd image {} size matches the configuration"


### PR DESCRIPTION
When resizing a rbd target, local gateway node will firstly update
RBD image size, then all gateway update LUN size in LIO accordingly.
size_bytes should also be updated with new RBD image size.

Signed-off-by: Zhang Zhuoyu <zhangzhuoyu@cmss.chinamobile.com>
Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>