### PR TITLE
Enable initiator name based ACL support (v2)

### DIFF
--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -175,6 +175,9 @@ class GWTarget(object):
         try:
             tpg = TPG(self.target)
 
+            # Use initiator name based ACL by default.
+            tpg.set_attribute('authentication', '0');
+
             self.logger.debug("(Gateway.create_tpg) Added tpg for portal "
                               "ip {}".format(ip))
             if ip == self.active_portal_ip:


### PR DESCRIPTION
This just adds support for initiator name based ACL support.
It is enabled by default and turned off if CHAP is setup for
any client.