### PR TITLE
gateway: fix lun size mismatch when gateway restart

### DIFF
--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -43,7 +43,7 @@ class Settings(object):
 
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):
 
-        self.size_suffixes = ['M', 'G', 'T']
+        self.size_suffixes = ['B', 'K', 'M', 'G', 'T']
 
         self.error = False
         self.error_msg = ''

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -180,7 +180,7 @@ def get_ip_address(iscsi_network):
 
 def convert_2_bytes(disk_size):
 
-    power = [2, 3, 4]
+    power = [0, 1, 2, 3, 4]
     unit = disk_size[-1].upper()
     offset = settings.config.size_suffixes.index(unit)
     value = int(disk_size[:-1])     # already validated, so no need for

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -191,20 +191,6 @@ def convert_2_bytes(disk_size):
     return _bytes
 
 
-def human_size(num):
-    """
-    convert a bytes value into a more human readable format
-    :param num(int): bytes
-    :return: Size as M/G/T suffixed
-    """
-    for unit, precision in [('b', 0), ('K', 0), ('M', 0), ('G', 0), ('T', 0),
-                            ('P', 1), ('E', 2), ('Z', 2)]:
-        if abs(num) < 1024.0:
-            return "{0:.{1}f}{2}".format(num, precision, unit)
-        num /= 1024.0
-    return "{0:.2f}{1}".format(num, "Y")
-
-
 def get_pool_id(conf=None, pool_name='rbd'):
     """
     Query Rados to get the pool id of a given pool name

--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -25,7 +25,7 @@ from ceph_iscsi_config.lun import LUN
 from ceph_iscsi_config.client import GWClient, CHAP
 from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.lio import LIO, Gateway
-from ceph_iscsi_config.utils import this_host, human_size
+from ceph_iscsi_config.utils import this_host
 
 # Create a flask instance
 app = Flask(__name__)
@@ -300,7 +300,7 @@ def define_luns(gateway):
                         try:
                             with rbd.Image(ioctx, image_name) as rbd_image:
                                 image_bytes = rbd_image.size()
-                                image_size_h = human_size(image_bytes)
+                                image_size_h = str(image_bytes) + 'b'
 
                                 lun = LUN(logger, pool, image_name,
                                           image_size_h, local_gw)


### PR DESCRIPTION
When gateway restart and define luns from config object, convert
image size from bytes to human readable size will lose of precision,
which will cause add_dev_to_lio failed with "Mismatched sizes"
checking error.

Signed-off-by: Zhuoyu Zhang <zhangzhuoyu@cmss.chinamobile.com>