### PR TITLE
lun: use a copy of control dict when instantiating LUN

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -224,7 +224,7 @@ class LUN(object):
 
         self._validate_request()
         if self.config_key in self.config.config['disks']:
-            self.controls = self.config.config['disks'][self.config_key].get('controls', {})
+            self.controls = self.config.config['disks'][self.config_key].get('controls', {}).copy()
 
     def _get_max_data_area_mb(self):
         max_data_area_mb = self.controls.get('max_data_area_mb', None)


### PR DESCRIPTION
Without the copy, self.controls is a reference to the
controls dictionary in the config object, which results
in failing to identify (and sync) lun config changes
when the two dictionaries are compared.

Signed-off-by: Venky Shankar <vshankar@redhat.com>