### PR TITLE
Fix size mismatch

### DIFF
--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -107,8 +107,6 @@ class Settings(object):
 
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):
 
-        self.size_suffixes = ['M', 'G', 'T']
-
         self.error = False
         self.error_msg = ''
 

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -211,20 +211,6 @@ def convert_2_bytes(disk_size):
     return _bytes
 
 
-def human_size(num):
-    """
-    convert a bytes value into a more human readable format
-    :param num(int): bytes
-    :return: Size as M/G/T suffixed
-    """
-    for unit, precision in [('b', 0), ('K', 0), ('M', 0), ('G', 0), ('T', 0),
-                            ('P', 1), ('E', 2), ('Z', 2)]:
-        if abs(num) < 1024.0:
-            return "{0:.{1}f}{2}".format(num, precision, unit)
-        num /= 1024.0
-    return "{0:.2f}{1}".format(num, "Y")
-
-
 def get_pool_id(conf=None, pool_name='rbd'):
     """
     Query Rados to get the pool id of a given pool name

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -15,6 +15,8 @@ import ceph_iscsi_config.settings as settings
 
 __author__ = 'pcuzner@redhat.com'
 
+size_suffixes = ['M', 'G', 'T']
+
 class CephiSCSIError(Exception):
     '''
     Generic Ceph iSCSI config error.
@@ -92,7 +94,7 @@ def valid_size(size):
     valid = True
     unit = size[-1]
 
-    if unit.upper() not in settings.config.size_suffixes:
+    if unit.upper() not in size_suffixes:
         valid = False
     else:
         try:
@@ -193,7 +195,7 @@ def convert_2_bytes(disk_size):
 
     power = [2, 3, 4]
     unit = disk_size[-1].upper()
-    offset = settings.config.size_suffixes.index(unit)
+    offset = size_suffixes.index(unit)
     value = int(disk_size[:-1])     # already validated, so no need for
                                     # try/except clause
 

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -193,6 +193,13 @@ def get_ip_address(iscsi_network):
 
 def convert_2_bytes(disk_size):
 
+    try:
+        # If it's already an integer or a string with no suffix then assume
+        # it's already in bytes.
+        return int(disk_size)
+    except ValueError:
+        pass
+
     power = [2, 3, 4]
     unit = disk_size[-1].upper()
     offset = size_suffixes.index(unit)

--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -25,7 +25,7 @@ from ceph_iscsi_config.lun import LUN
 from ceph_iscsi_config.client import GWClient
 from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.lio import LIO, Gateway
-from ceph_iscsi_config.utils import this_host, human_size, CephiSCSIError
+from ceph_iscsi_config.utils import this_host, CephiSCSIError
 
 # Create a flask instance
 app = Flask(__name__)


### PR DESCRIPTION
From @zhuozh's description for PR
https://github.com/ceph/ceph-iscsi-config/pull/50:

When gateway restart and define luns from config object, convert
image size from bytes to human readable size will lose of precision,
which will cause add_dev_to_lio failed with "Mismatched sizes"
checking error.