### PR TITLE
Allow alua failover type to be configurable

### DIFF
--- a/ceph_iscsi_config/alua.py
+++ b/ceph_iscsi_config/alua.py
@@ -1,240 +1,69 @@
-'''
-This will eventually be moved to rtslib-fb, so it can be used
-by targetcli-fb
-'''
-
-__author__ = 'Michael Christie'
-
+from rtslib_fb.alua import ALUATargetPortGroup
 from rtslib_fb import BlockStorageObject
 from rtslib_fb.target import TPG
-from rtslib_fb.node import CFSNode
-from rtslib_fb.utils import RTSLibError, fread, fwrite
-from rtslib_fb import root
 
-class ALUATargetPortGroup(CFSNode):
-    """
-    ALUA Target Port Group interface
-    """
+import ceph_iscsi_config.settings as settings
 
-    def __repr__(self):
-        return "<ALUA TPG %s>" % self.name
+def alua_format_group_name(tpg, failover_type, is_owner):
+    if is_owner:
+        return "ao"
 
-    def __init__(self, storage_obj, name, tag=None):
-        """
-        @param storage_obj: backstore storage object to create ALUA group for
-        @param name: name of ALUA group
-        @param tag: target port group id. If not passed in, try to look
-                    up existing ALUA TPG with the same name
-        """
+    if failover_type == "explicit":
+        return "standby{}".format(tpg.tag)
+    else:
+        return "ano{}".format(tpg.tag)
 
-        # default_tg_pt_gp takes tag 1
-        if tag is not None and (tag > 65535 or tag < 1):
-            raise RTSLibError("The TPG Tag must be between 1 and 65535")
+def alua_create_ao_group(so, tpg, group_name):
+    alua_tpg = ALUATargetPortGroup(so, group_name, tpg.tag)
+    alua_tpg.alua_support_active_optimized = 1
+    alua_tpg.alua_access_state = 0
 
-        super(ALUATargetPortGroup, self).__init__()
-        self.name = name
-        self.storage_obj = storage_obj
+    return alua_tpg
 
-        self._path = "%s/alua/%s" % (storage_obj.path, name)
+def alua_create_implicit_group(tpg, so, group_name, is_owner):
+    if is_owner:
+        alua_tpg = alua_create_ao_group(so, tpg, group_name)
+    else:
+        alua_tpg = ALUATargetPortGroup(so, group_name, tpg.tag)
+        alua_tpg.alua_access_state = 1
 
-        if tag is not None:
-            try:
-                self._create_in_cfs_ine('create')
-            except OSError as msg:
-                raise RTSLibError(msg)
+    alua_tpg.alua_support_active_nonoptimized = 1
+    alua_tpg.alua_access_type = 1
+    # Just make sure we get to at least attempt one op for the failover
+    # process.
+    alua_tpg.implicit_trans_secs = settings.config.osd_op_timeout + 15
+    return alua_tpg
 
-            try:
-                fwrite("%s/tg_pt_gp_id" % self._path, tag)
-            except IOError as msg:
-                self.delete()
-                raise RTSLibError("Cannot set id to %d: %s" % (tag, str(msg)))
-        else:
-            try:
-                self._create_in_cfs_ine('lookup')
-            except OSError as msg:
-                raise RTSLibError(msg)
+def alua_create_explicit_group(tpg, so, group_name, is_owner):
+    if is_owner:
+        alua_tpg = alua_create_ao_group(so, tpg, group_name)
+        alua_tpg.preferred = 1
+    else:
+        alua_tpg = ALUATargetPortGroup(so, group_name, tpg.tag)
 
-    # Public
+    alua_tpg.alua_support_standby = 1
+    # Use Explicit but also set the Implicit bit so we can
+    # update the kernel from configfs.
+    alua_tpg.alua_access_type = 3
+    # start ports in Standby, and let the initiator drive the initial
+    # transition to AO.
+    alua_tpg.alua_access_state = 2
+    return alua_tpg
 
-    def bind_to_lun(self, mapped_lun):
-        path = "%s/alua_tg_pt_gp" % mapped_lun.path
-        try:
-            fwrite(path, str(self.name))
-        except IOError as msg:
-            raise RTSLibError("Cannot set tpg: " % str(msg))
+def alua_create_group(failover_type, tpg, so, is_owner):
+    group_name = alua_format_group_name(tpg, failover_type, is_owner)
 
-    def delete(self):
-        """
-        Delete ALUA TPG and unmap LUNs
-        """
-        self._check_self()
-        # This will reset the ALUA tpg to default_tg_pt_gp
-        super(ALUATargetPortGroup, self).delete()
+    if failover_type == "explicit":
+        alua_tpg = alua_create_explicit_group(tpg, so, group_name, is_owner)
+    else:
+        # tmp drop down to implicit. Next patch will check for "implicit"
+        # and add error handling up the stack if the failover_type is invalid.
+        alua_tpg = alua_create_implicit_group(tpg, so, group_name, is_owner)
 
-    def _get_alua_access_state(self):
-        self._check_self()
-        path = "%s/alua_access_state" % self.path
-        return int(fread(path))
+    alua_tpg.alua_support_active_optimized = 1
+    alua_tpg.alua_support_offline = 0
+    alua_tpg.alua_support_unavailable = 0
+    alua_tpg.alua_support_transitioning = 1
+    alua_tpg.nonop_delay_msecs = 0
 
-    def _set_alua_access_state(self, newstate):
-        self._check_self()
-        path = "%s/alua_access_state" % self.path
-        try:
-            fwrite(path, str(int(newstate)))
-        except IOError as e:
-            raise RTSLibError("Cannot change ALUA state: %s" % e)
-
-    def _get_alua_access_type(self):
-        self._check_self()
-        path = "%s/alua_access_type" % self.path
-        return int(fread(path))
-
-    def _set_alua_access_type(self, access_type):
-        self._check_self()
-        path = "%s/alua_access_type" % self.path
-        try:
-            fwrite(path, str(int(access_type)))
-        except IOError as e:
-            raise RTSLibError("Cannot change ALUA access type: %s" % e)
-
-    def _get_preferred(self):
-        self._check_self()
-        path = "%s/preferred" % self.path
-        return int(fread(path))
-
-    def _set_preferred(self, pref):
-        self._check_self()
-        path = "%s/preferred" % self.path
-        try:
-            fwrite(path, str(int(pref)))
-        except IOError as e:
-            raise RTSLibError("Cannot set preferred: %s" % e)
-
-    def _get_alua_support_active_nonoptimized(self):
-        self._check_self()
-        path = "%s/alua_support_active_nonoptimized" % self.path
-        return int(fread(path))
-
-    def _set_alua_support_active_nonoptimized(self, enabled):
-        self._check_self()
-        path = "%s/alua_support_active_nonoptimized" % self.path
-        try:
-            fwrite(path, str(int(enabled)))
-        except IOError as e:
-            raise RTSLibError("Cannot set alua_support_active_nonoptimized: %s" % e)
-
-    def _get_alua_support_active_optimized(self):
-        self._check_self()
-        path = "%s/alua_support_active_optimized" % self.path
-        return int(fread(path))
-
-    def _set_alua_support_active_optimized(self, enabled):
-        self._check_self()
-        path = "%s/alua_support_active_optimized" % self.path
-        try:
-            fwrite(path, str(int(enabled)))
-        except IOError as e:
-            raise RTSLibError("Cannot set alua_support_active_optimized: %s" % e)
-
-    def _get_alua_support_offline(self):
-        self._check_self()
-        path = "%s/alua_support_offline" % self.path
-        return int(fread(path))
-
-    def _set_alua_support_offline(self, enabled):
-        self._check_self()
-        path = "%s/alua_support_offline" % self.path
-        try:
-            fwrite(path, str(int(enabled)))
-        except IOError as e:
-            raise RTSLibError("Cannot set alua_support_offline: %s" % e)
-
-    def _get_alua_support_unavailable(self):
-        self._check_self()
-        path = "%s/alua_support_unavailable" % self.path
-        return int(fread(path))
-
-    def _set_alua_support_unavailable(self, enabled):
-        self._check_self()
-        path = "%s/alua_support_unavailable" % self.path
-        try:
-            fwrite(path, str(int(enabled)))
-        except IOError as e:
-            raise RTSLibError("Cannot set alua_support_unavailable: %s" % e)
-
-    def _get_alua_support_standby(self):
-        self._check_self()
-        path = "%s/alua_support_standby" % self.path
-        return int(fread(path))
-
-    def _set_alua_support_standby(self, enabled):
-        self._check_self()
-        path = "%s/alua_support_standby" % self.path
-        try:
-            fwrite(path, str(int(enabled)))
-        except IOError as e:
-            raise RTSLibError("Cannot set alua_support_standby: %s" % e)
-
-    def _get_tpg_id(self):
-        self._check_self()
-        path = "%s/tg_pt_gp_id" % self.path
-        return int(fread(path))
-
-    def _get_nonop_delay_msecs(self):
-        self._check_self()
-        path = "%s/nonop_delay_msecs" % self.path
-        return int(fread(path))
-
-    def _set_nonop_delay_msecs(self, delay):
-        self._check_self()
-        path = "%s/nonop_delay_msecs" % self.path
-        try:
-            fwrite(path, str(int(delay)))
-        except IOError as e:
-            raise RTSLibError("Cannot set nonop_delay_msecs: %s" % e)
-
-    alua_access_state = property(_get_alua_access_state, _set_alua_access_state,
-                                 doc="Get or set ALUA state. "
-                                     "0 = Active/optimized, "
-                                     "1 = Active/non-optimized, "
-                                     "2 = Standby, "
-                                     "3 = Unavailable, "
-                                     "14 = Offline")
-
-    alua_access_type = property(_get_alua_access_type, _set_alua_access_type,
-                                doc="Get or set ALUA access type. "
-                                    "1 = Implicit, 2 = Explicit, 3 = Both")
-
-    preferred = property(_get_preferred, _set_preferred,
-                         doc="Get or set preferred bit. 1 = Pref, 0 Not-Pre")
-
-    tpg_id = property(_get_tpg_id,
-                      doc="Get ALUA Target Port Group ID")
-
-    alua_support_active_nonoptimized = property(_get_alua_support_active_nonoptimized,
-                                                _set_alua_support_active_nonoptimized,
-                                                doc="Enable (1) or disable (0) "
-                                                    "Active/non-optimized support")
-
-    alua_support_active_optimized = property(_get_alua_support_active_optimized,
-                                             _set_alua_support_active_optimized,
-                                             doc="Enable (1) or disable (0) "
-                                                 "Active/optimized support")
-
-    alua_support_offline = property(_get_alua_support_offline,
-                                    _set_alua_support_offline,
-                                    doc="Enable (1) or disable (0) "
-                                        "offline support")
-
-    alua_support_unavailable = property(_get_alua_support_unavailable,
-                                        _set_alua_support_unavailable,
-                                        doc="enable (1) or disable (0) "
-                                            "unavailable support")
-    alua_support_standby = property(_get_alua_support_standby,
-                                    _set_alua_support_standby,
-                                    doc="enable (1) or disable (0) "
-                                        "standby support")
-
-    nonop_delay_msecs = property(_get_nonop_delay_msecs, _set_nonop_delay_msecs,
-                                 doc="msecs to delay IO when non-optimized")
-
+    return alua_tpg

--- a/ceph_iscsi_config/alua.py
+++ b/ceph_iscsi_config/alua.py
@@ -3,6 +3,7 @@ from rtslib_fb import BlockStorageObject
 from rtslib_fb.target import TPG
 
 import ceph_iscsi_config.settings as settings
+from ceph_iscsi_config.utils import CephiSCSIInval
 
 def alua_format_group_name(tpg, failover_type, is_owner):
     if is_owner:
@@ -55,10 +56,12 @@ def alua_create_group(failover_type, tpg, so, is_owner):
 
     if failover_type == "explicit":
         alua_tpg = alua_create_explicit_group(tpg, so, group_name, is_owner)
-    else:
+    elif failover_type == "implicit":
         # tmp drop down to implicit. Next patch will check for "implicit"
         # and add error handling up the stack if the failover_type is invalid.
         alua_tpg = alua_create_implicit_group(tpg, so, group_name, is_owner)
+    else:
+        raise CephiSCSIInval("Invalid failover type {}".format(failover_type))
 
     alua_tpg.alua_support_active_optimized = 1
     alua_tpg.alua_support_offline = 0

--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -387,22 +387,21 @@ class GWTarget(object):
         except CephiSCSIInval as err:
             raise
         except RTSLibError as err:
-                self.logger.info("ALUA group id {} for stg obj {} lun {} "
-                                 "already made".format(tpg.tag, stg_object, lun))
-                group_name = alua_format_group_name(tpg,
-                                                    settings.config.alua_failover_type,
-                                                    is_owner)
-                # someone mapped a LU then unmapped it without deleting the
-                # stg_object, or we are reloading the config.
-                alua_tpg = ALUATargetPortGroup(stg_object, group_name)
-                if alua_tpg.tpg_id != tpg.tag:
-                    # ports and owner were rearranged. Not sure we support that.
-                    raise CephiSCSIInval("Existing ALUA group tag for group {} "
-                                         "in invalid state.\n".format(
-                                         group_name))
+            self.logger.info("ALUA group id {} for stg obj {} lun {} "
+                             "already made".format(tpg.tag, stg_object, lun))
+            group_name = alua_format_group_name(tpg,
+                                                settings.config.alua_failover_type,
+                                                is_owner)
+            # someone mapped a LU then unmapped it without deleting the
+            # stg_object, or we are reloading the config.
+            alua_tpg = ALUATargetPortGroup(stg_object, group_name)
+            if alua_tpg.tpg_id != tpg.tag:
+                # ports and owner were rearranged. Not sure we support that.
+                raise CephiSCSIInval("Existing ALUA group tag for group {} "
+                                     "in invalid state.\n".format(group_name))
 
-                # drop down in case we are restarting due to error and we
-                # were not able to bind to a lun last time.
+            # drop down in case we are restarting due to error and we
+            # were not able to bind to a lun last time.
 
         self.logger.info("Setup group {} for {} on tpg {} (state {}, owner {}, "
                          "failover type {})".format(alua_tpg.name,

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -14,7 +14,6 @@ from rtslib_fb.alua import ALUATargetPortGroup
 import ceph_iscsi_config.settings as settings
 
 from ceph_iscsi_config.common import Config
-# from ceph_iscsi_config.alua import ALUATargetPortGroup
 from ceph_iscsi_config.utils import (convert_2_bytes, gen_control_string,
                                      get_pool_id, ipv4_addresses,
                                      this_host, CephiSCSIError)

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -102,7 +102,8 @@ class Settings(object):
                        "max_burst_length": 524288,
                        "max_recv_data_segment_length": 262144,
                        "max_xmit_data_segment_length": 262144,
-                       "max_data_area_mb" : 8
+                       "max_data_area_mb" : 8,
+                       "alua_failover_type" : "implicit"
                        }
 
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):

--- a/ceph_iscsi_config/utils.py
+++ b/ceph_iscsi_config/utils.py
@@ -23,6 +23,12 @@ class CephiSCSIError(Exception):
     '''
     pass
 
+class CephiSCSIInval(CephiSCSIError):
+    '''
+    Invalid setting/param.
+    '''
+    pass
+
 def shellcommand(command_string):
 
     try:

--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -319,7 +319,8 @@ def apply_config():
         logger.info("Adding the IP to the enabled tpg, allowing iSCSI logins")
         gateway.enable_active_tpg(config)
         if gateway.error:
-            halt("Error enabling the IP with the active TPG")
+            halt("Error enabling the IP with the active TPG: {}".format(
+                 gateway.error_msg))
 
     config_loading = False
 


### PR DESCRIPTION
These patches allow us to configure the alua failover type to be used. It supports implicit and explicit and uses implicit by default.