### PR TITLE
Control/setting changes

### DIFF
--- a/ceph_iscsi_config/gateway_object.py
+++ b/ceph_iscsi_config/gateway_object.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+import ceph_iscsi_config.settings as settings
+from ceph_iscsi_config.common import Config
+from ceph_iscsi_config.utils import CephiSCSIError
+
+
+class GWObject(object):
+    def __init__(self, cfg_type, cfg_type_key, logger, control_settings):
+        self.control_settings = control_settings
+        self.cfg_type = cfg_type
+        self.cfg_type_key = cfg_type_key
+        self.logger = logger
+
+        self.config = Config(self.logger)
+        if self.config.error:
+            raise CephiSCSIError(self.config.error_msg)
+
+        # Copy of controls that will not be written until commit is called.
+        # To update the kernel call the child object's update function.
+        self.controls = self._get_config_controls().copy()
+        self._add_properies()
+
+    def _set_config_controls(self, config, controls):
+        if self.cfg_type_key:
+            config.config[self.cfg_type][self.cfg_type_key]['controls'] = controls
+        else:
+            config.config['controls'] = controls
+
+    def _get_config_controls(self):
+        # global controls
+        if self.cfg_type == 'controls':
+            return self.config.config.get('controls', {})
+
+        # This might be the initial creation so it will not be in the
+        # config yet
+        if self.cfg_type_key in self.config.config[self.cfg_type]:
+            return self.config.config[self.cfg_type][self.cfg_type_key].get('controls', {})
+        else:
+            return {}
+
+    def _get_control(self, key):
+        value = self.controls.get(key, None)
+        if value is not None:
+            value = settings.Settings.normalize(key, value)
+        if value is None:
+            return getattr(settings.config, key)
+        return value
+
+    def _set_control(self, key, value):
+        if value is None or \
+           settings.Settings.normalize(key, value) == getattr(settings.config, key):
+            self.controls.pop(key, None)
+        else:
+            self.controls[key] = value
+
+    def _add_properies(self):
+        for k in self.control_settings:
+            setattr(GWObject, k,
+                    property(lambda self, k=k: self._get_control(k),
+                             lambda self, v, k=k: self._set_control(k, v)))
+
+    def commit_controls(self):
+        committed_controls = self._get_config_controls()
+
+        if self.controls != committed_controls:
+            # update our config
+            self._set_config_controls(self.config, self.controls)
+
+            # update remote config
+            if self.cfg_type == 'controls':
+                self.config.update_item(self.cfg_type, self.cfg_type_key,
+                                        self.controls)
+            else:
+                updated_obj = self.config.config[self.cfg_type][self.cfg_type_key]
+                self.config.update_item(self.cfg_type, self.cfg_type_key,
+                                        updated_obj)
+
+        self.config.commit()
+        if self.config.error:
+            raise CephiSCSIError(self.config.error_msg)

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -745,7 +745,7 @@ class LUN(GWObject):
                                               config=cfgstring,
                                               size=self.size_bytes,
                                               wwn=in_wwn, control=control_string)
-        except RTSLibError as err:
+        except (RTSLibError, IOError) as err:
             self.error = True
             self.error_msg = ("failed to add {} to LIO - "
                               "error({})".format(self.config_key,

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -223,7 +223,8 @@ class LUN(GWObject):
     SETTINGS = [
         "max_data_area_mb",
         "qfull_timeout",
-        "osd_op_timeout"]
+        "osd_op_timeout",
+        "hw_max_sectors"]
 
     def __init__(self, logger, pool, image, size, allocating_host):
         self.logger = logger
@@ -631,7 +632,7 @@ class LUN(GWObject):
 
         # extract control parameter overrides (if any) or use default
         controls = {}
-        for k in ['max_data_area_mb']:
+        for k in ['max_data_area_mb', 'hw_max_sectors']:
             controls[k] = getattr(self, k)
 
         control_string = gen_control_string(controls)

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -718,9 +718,10 @@ class LUN(GWObject):
         :return: (str) either 'ok' or an error description
         """
 
+        # create can also pass optional controls dict
         mode_vars = {"create": ['pool', 'image', 'size', 'count'],
                      "resize": ['pool', 'image', 'size'],
-                     "reconfigure": ['pool', 'image', 'max_data_area_mb'],
+                     "reconfigure": ['pool', 'image', 'controls'],
                      "delete": ['pool', 'image']}
 
         if 'mode' in kwargs.keys():
@@ -793,11 +794,13 @@ class LUN(GWObject):
                         "current size ({}/{})".format(human_size(current_size),
                                                       current_size))
 
-        if mode == 'reconfigure':
+        if mode in ['create', 'reconfigure']:
 
-            max_data_area_mb = kwargs['max_data_area_mb']
-            if max_data_area_mb and not str(max_data_area_mb).isdigit():
-                return ("max_data_area_mb must be an integer in MiB")
+            try:
+                settings.Settings.normalize_controls(kwargs['controls'],
+                                                     LUN.SETTINGS)
+            except ValueError as err:
+                return(err)
 
         if mode == 'delete':
 

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -22,6 +22,40 @@ class Settings(object):
     _int_regex = re.compile("^[0-9]+")
 
     @staticmethod
+    def normalize_controls(raw_controls, settings_list):
+        """
+        Convert a controls dictionary from a json converted or a user input
+        dictionary where the values are strings.
+        """
+        controls = {}
+
+        for key, raw_value in raw_controls.iteritems():
+            if key not in settings_list:
+                raise ValueError("Supported controls: {}".format(",".join(settings_list)))
+
+            if not raw_value:
+                # Use the default/reset.
+                controls[key] = None
+                continue
+
+            # Do not use normalize() because if the user inputs invalid
+            # values we want to pass up more detailed errors.
+            if key in Settings.LIO_YES_NO_SETTINGS:
+                try:
+                    value = Settings.convert_lio_yes_no(raw_value)
+                except ValueError:
+                    raise ValueError("expected yes or no for {}".format(key))
+            else:
+                try:
+                    value = int(raw_value)
+                except ValueError:
+                    raise ValueError("expected integer for {}".format(key))
+
+            controls[key] = value
+
+        return controls
+
+    @staticmethod
     def convert_lio_yes_no(value):
         """
         Convert true/false/yes/no to boolean

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -16,19 +16,6 @@ def init():
 
 
 class Settings(object):
-    GATEWAY_SETTINGS = [
-        "dataout_timeout",
-        "nopin_response_timeout",
-        "nopin_timeout",
-        "cmdsn_depth",
-        "immediate_data",
-        "initial_r2t",
-        "max_outstanding_r2t",
-        "first_burst_length",
-        "max_burst_length",
-        "max_recv_data_segment_length",
-        "max_xmit_data_segment_length"]
-
     LIO_YES_NO_SETTINGS = ["immediate_data", "initial_r2t"]
 
     _float_regex = re.compile("^[0-9]*\.{1}[0-9]$")

--- a/ceph_iscsi_config/settings.py
+++ b/ceph_iscsi_config/settings.py
@@ -125,7 +125,8 @@ class Settings(object):
                        "max_recv_data_segment_length": 262144,
                        "max_xmit_data_segment_length": 262144,
                        "max_data_area_mb": 8,
-                       "alua_failover_type": "implicit"
+                       "alua_failover_type": "implicit",
+                       "hw_max_sectors": "1024"
                        }
 
     def __init__(self, conffile='/etc/ceph/iscsi-gateway.cfg'):


### PR DESCRIPTION
The following patches syncs up how controls and settings are handled for the gateway objects like the target, client and lun. This makes it easier to share and use the code with gwcli and ceph-ansible.