### PR TITLE
build/ops: rpm: set Group in spec file

### DIFF
--- a/ceph-iscsi-config.spec
+++ b/ceph-iscsi-config.spec
@@ -18,6 +18,7 @@
 Name:           ceph-iscsi-config
 Version:        2.7
 Release:        1%{?dist}
+Group:          System/Filesystems
 Summary:        Python package providing modules for ceph iscsi gateway configuration management
 
 License:        GPL-3.0-or-later


### PR DESCRIPTION
Using the same Group as we do for Ceph.

Signed-off-by: Nathan Cutler <ncutler@suse.com>