### PR TITLE
build/ops: rpm: use %license macro unconditionally

### DIFF
--- a/ceph-iscsi-config.spec
+++ b/ceph-iscsi-config.spec
@@ -70,13 +70,8 @@ install -m 0644 .%{_unitdir}/rbd-target-gw.service %{buildroot}%{_unitdir}
 /bin/systemctl --system enable rbd-target-gw &> /dev/null || :
 
 %files
-%if 0%{?suse_version}
 %license LICENSE
 %license COPYING
-%else
-%doc LICENSE
-%doc COPYING
-%endif
 %doc README
 %doc iscsi-gateway.cfg_sample
 %{python2_sitelib}/*


### PR DESCRIPTION
see https://rpm-guide.readthedocs.io/en/latest/rpm-guide.html#rpm-macros

Signed-off-by: Nathan Cutler <ncutler@suse.com>