### PR TITLE
Fix api default port info

### DIFF
--- a/iscsi-gateway.cfg_sample
+++ b/iscsi-gateway.cfg_sample
@@ -23,7 +23,7 @@ api_secure = false
 # Additional API configuration options are as follows (defaults shown);
 # api_user = admin
 # api_password = admin
-# api_port = 5001
+# api_port = 5000
 # trusted_ip_list = IP,IP
 
 # Refer to the ceph-iscsi-config/settings module for more options


### PR DESCRIPTION
The default api_port in settings.py is 5000 and not 5001.

Note: I think there was a funky ending char in the file. When I edit
this file with a editor in linux it keeps fixing it so there is a extra
change in the patch at the end of the file.