### PR TITLE
Move logs to dir

### DIFF
--- a/ceph-iscsi-config.spec
+++ b/ceph-iscsi-config.spec
@@ -77,6 +77,7 @@ install -m 0644 .%{_unitdir}/rbd-target-gw.service %{buildroot}%{_unitdir}
 %{python2_sitelib}/*
 %{_bindir}/rbd-target-gw
 %{_unitdir}/rbd-target-gw.service
+%attr(0770,root,root) %dir %{_localstatedir}/log/rbd-target-gw
 
 %changelog
 

--- a/rbd-target-gw.py
+++ b/rbd-target-gw.py
@@ -406,7 +406,7 @@ if __name__ == '__main__':
     syslog_handler.setFormatter(syslog_format)
 
     # file target - more verbose logging for diagnostics
-    file_handler = RotatingFileHandler('/var/log/rbd-target-gw.log',
+    file_handler = RotatingFileHandler('/var/log/rbd-target-gw/rbd-target-gw.log',
                                        maxBytes=5242880,
                                        backupCount=7)
     file_handler.setLevel(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     scripts=[
         "rbd-target-gw.py"
     ],
+    data_files=[("/var/log/rbd-target-gw", [])],
     cmdclass={
         "install_scripts": StripExtension
     }


### PR DESCRIPTION
The ceph selinux policy expects the logs to be in a dir under /var/log,
so this just moves our logs to /var/log/rbd-target-gw, so we do not have
to special case the ceph iscsi stuff in ceph-selinux.