### PR TITLE
Do not use TimeoutStopSec infinity

### DIFF
--- a/usr/lib/systemd/system/rbd-target-gw.service
+++ b/usr/lib/systemd/system/rbd-target-gw.service
@@ -21,7 +21,7 @@ PrivateTmp=true
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
-TimeoutStopSec=infinity
+TimeoutStopSec=600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If infinity is not supported in systemd it will kill the daemon right
away leaving the system in a inconsistent state. This sets it to 600
seconds which for the normal case will be long enough to clean up.
However, for the failure case where the link to the ceph cluster is
flakey/bad and it takes a long time to get the config object and close
images, we can still  be killed in the middle of cleanup then we could
hit the same issues. For that issue I think we will need more invassive
changes or just spit an error and tell the user to run targetcli by
hand.