### PR TITLE
Handle bs cache and configfs errors

### DIFF
--- a/ceph_iscsi_config/gateway.py
+++ b/ceph_iscsi_config/gateway.py
@@ -17,6 +17,7 @@ from ceph_iscsi_config.common import Config
 from ceph_iscsi_config.alua import alua_create_group, alua_format_group_name
 from ceph_iscsi_config.client import GWClient
 from ceph_iscsi_config.gateway_object import GWObject
+from ceph_iscsi_config.lio import LIO
 
 __author__ = 'pcuzner@redhat.com'
 
@@ -200,9 +201,9 @@ class GWTarget(GWObject):
         :return: None
         """
         # check that there aren't any disks or clients in the configuration
-        lio_root = root.RTSRoot()
+        lio = LIO()
 
-        disk_count = len([disk for disk in lio_root.storage_objects])
+        disk_count = len([disk for disk in lio.ceph_storage_objects(self.config)])
         clients = []
         for tpg in self.tpg_list:
             tpg_clients = [node for node in tpg._list_node_acls()]
@@ -400,11 +401,9 @@ class GWTarget(GWObject):
         so this method, brings those objects into the gateways TPG
         """
 
-        lio_root = root.RTSRoot()
-
+        lio = LIO()
         # process each storage object added to the gateway, and map to the tpg
-        for stg_object in lio_root.storage_objects:
-
+        for stg_object in lio.ceph_storage_objects(config):
             for tpg in self.tpg_list:
                 self.logger.debug("processing tpg{}".format(tpg.tag))
 

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -741,6 +741,10 @@ class LUN(GWObject):
             if (settings.config.cephconf != '/etc/ceph/ceph.conf'):
                 cfgstring += ";conf={}".format(settings.config.cephconf)
 
+            # Another app might have created/removed the dev. Force the cache
+            # to update itself.
+            lio_root = root.RTSRoot()
+            lio_root.invalidate_caches()
             new_lun = UserBackedStorageObject(name=self.config_key,
                                               config=cfgstring,
                                               size=self.size_bytes,


### PR DESCRIPTION
If gwcli or ceph-ansible creates/deletes a disk then the rtslib bs cache
will be stale. This adds a invalidate caches call to force the cache to
be updated during device creation. For object creations done via
configfs scanning (querys via storage_objects/storage_object refs) this
rtslib patch

https://github.com/open-iscsi/rtslib-fb/pull/141

bypasses the cache.

Note that with that patch we could also manage the index creation and
completely avoid the cache, but it looks like it is a gluster and
targetcli specific issue that causes dev creation to take a minute for
one device. I tested 1024 devices and it was less than a second for each
device.