### PR TITLE
Fix session check during lun deactivate

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -366,8 +366,6 @@ class LUN(GWObject):
             for mlun in alun.mapped_luns:
                 node_acl = mlun.parent_nodeacl
 
-        for attached_lun in so.attached_luns:
-            for node_acl in attached_lun.parent_tpg.node_acls:
                 if node_acl.session and \
                         node_acl.session.get('state', '').upper() == 'LOGGED_IN':
                     raise CephiSCSIError("LUN {} in-use".format(self.image))


### PR DESCRIPTION
In the ceph-iscsi-cli commit:

commit 9cec0ddbccaeffbaa6212360dd64019172a839d6
Author: Jason Dillaman <dillaman@redhat.com>
Date:   Fri Oct 26 09:08:30 2018 -0400

    Fixed flake8 warnings

there was a mismerge due to a conflict and it added back the old
attached lun check bypassing the mapped lun check which was needed to
make sure we only test if a lun is mapped to a client before trying to
deactivate. The ceph-isccsi-config lun deactivate call was then based on
that ceph-iscsi-cli code.

This patch reverts the attached lun only check.