### PR TITLE
Check for max supported disks during lun validation

### DIFF
--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -841,6 +841,9 @@ class LUN(GWObject):
                 return "pool name is invalid"
 
         if mode == 'create':
+            if len(config['disks']) >= 256:
+                return "Disk limit of 256 reached."
+
             disk_regex = re.compile(r"^[a-zA-Z0-9\-_]+$")
             if not disk_regex.search(kwargs['pool']):
                 return "Invalid pool name (use alphanumeric, '_', or '-' characters)"


### PR DESCRIPTION
This moves the max luns check from ceph-iscsi-cli to ceph-iscsi-config.

Note:

The 256 value came from older kernels and rtslibs which had this limit.
Newer versions of the kernel support 64 bit luns and rtslib now supports
65536 unmapped luns and had a limit of 256 luns mapped to an ACL.

In future versions, we should have rtslib detect what the kernel
supports, base its limits on that, then export what it supports.