### PR TITLE
Make sure rtslib bs cache is clear

### DIFF
--- a/ceph_iscsi_config/lio.py
+++ b/ceph_iscsi_config/lio.py
@@ -17,6 +17,7 @@ class LIO(object):
     def ceph_storage_objects(self, config):
         disk_keys = config.config['disks'].keys()
 
+        self.lio_root.invalidate_caches()
         for stg_object in self.lio_root.storage_objects:
             if stg_object.name in disk_keys:
                 yield stg_object

--- a/ceph_iscsi_config/lun.py
+++ b/ceph_iscsi_config/lun.py
@@ -699,6 +699,7 @@ class LUN(GWObject):
     def lio_stg_object(self):
         found_it = False
         rtsroot = root.RTSRoot()
+        rtsroot.invalidate_caches()
         for stg_object in rtsroot.storage_objects:
 
             # First match on name, but then check the pool incase the same
@@ -790,6 +791,7 @@ class LUN(GWObject):
                     else:
                         break       # continue to the next tpg
 
+        lio_root.invalidate_caches()
         for stg_object in lio_root.storage_objects:
             if stg_object.name == self.config_key:
                 try:


### PR DESCRIPTION
Always clear rtslib bs cache when traversing the storage objects.
We do not want to rely on the rtslib fix in -70 in case users are
not able to upgrade.